### PR TITLE
Add scores for peptides to spectronaut output

### DIFF
--- a/post_process.py
+++ b/post_process.py
@@ -255,84 +255,84 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["DecoyType"]).strip()
 
-    tqdm.pandas(desc = "Annotating DecoyType...")
+    tqdm.pandas(desc = "Annotating decoy type...")
     spectronaut["PP.DecoyType"] = spectronaut.progress_apply(lambda row: annotate_DecoyType(row, index), axis = 1)
 
     def annotate_ProteinA(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["ProteinID"].split("_")[0]).strip()
 
-    tqdm.pandas(desc = "Annotating ProteinA...")
+    tqdm.pandas(desc = "Annotating protein A...")
     spectronaut["PP.ProteinA"] = spectronaut.progress_apply(lambda row: annotate_ProteinA(row, index), axis = 1)
 
     def annotate_ProteinB(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["ProteinID"].split("_")[1]).strip()
 
-    tqdm.pandas(desc = "Annotating ProteinB...")
+    tqdm.pandas(desc = "Annotating protein B...")
     spectronaut["PP.ProteinB"] = spectronaut.progress_apply(lambda row: annotate_ProteinB(row, index), axis = 1)
 
     def annotate_CrosslinkPositionProteinA(row: pd.Series, index: dict) -> int:
         key = get_key_spectronaut(row)
         return int(index[key]["rows"][0]["linkId"].split("-")[1].split("_")[0])
 
-    tqdm.pandas(desc = "Annotating CrosslinkPositionProteinA...")
+    tqdm.pandas(desc = "Annotating crosslink position in protein A...")
     spectronaut["PP.CrosslinkPositionProteinA"] = spectronaut.progress_apply(lambda row: annotate_CrosslinkPositionProteinA(row, index), axis = 1)
 
     def annotate_CrosslinkPositionProteinB(row: pd.Series, index: dict) -> int:
         key = get_key_spectronaut(row)
         return int(index[key]["rows"][0]["linkId"].split("-")[1].split("_")[1])
 
-    tqdm.pandas(desc = "Annotating CrosslinkPositionProteinB...")
+    tqdm.pandas(desc = "Annotating crosslink position in protein B...")
     spectronaut["PP.CrosslinkPositionProteinB"] = spectronaut.progress_apply(lambda row: annotate_CrosslinkPositionProteinB(row, index), axis = 1)
 
     def annotate_PeptideA(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["FragmentGroupId"].split("-")[0].split("_")[0]).strip()
 
-    tqdm.pandas(desc = "Annotating PeptideA...")
+    tqdm.pandas(desc = "Annotating peptide sequence A...")
     spectronaut["PP.PeptideA"] = spectronaut.progress_apply(lambda row: annotate_PeptideA(row, index), axis = 1)
 
     def annotate_PeptideB(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["FragmentGroupId"].split("-")[0].split("_")[1]).strip()
 
-    tqdm.pandas(desc = "Annotating PeptideB...")
+    tqdm.pandas(desc = "Annotating peptide sequence B...")
     spectronaut["PP.PeptideB"] = spectronaut.progress_apply(lambda row: annotate_PeptideB(row, index), axis = 1)
 
     def annotate_CrosslinkPositionPeptideA(row: pd.Series, index: dict) -> int:
         key = get_key_spectronaut(row)
         return int(index[key]["rows"][0]["FragmentGroupId"].split("-")[1].split(":")[0].split("_")[0])
 
-    tqdm.pandas(desc = "Annotating CrosslinkPositionPeptideA...")
+    tqdm.pandas(desc = "Annotating crosslink position in peptide A...")
     spectronaut["PP.CrosslinkPositionPeptideA"] = spectronaut.progress_apply(lambda row: annotate_CrosslinkPositionPeptideA(row, index), axis = 1)
 
     def annotate_CrosslinkPositionPeptideB(row: pd.Series, index: dict) -> int:
         key = get_key_spectronaut(row)
         return int(index[key]["rows"][0]["FragmentGroupId"].split("-")[1].split(":")[0].split("_")[1])
 
-    tqdm.pandas(desc = "Annotating CrosslinkPositionPeptideB...")
+    tqdm.pandas(desc = "Annotating crosslink position in peptide B...")
     spectronaut["PP.CrosslinkPositionPeptideB"] = spectronaut.progress_apply(lambda row: annotate_CrosslinkPositionPeptideB(row, index), axis = 1)
 
     def annotate_PeptidoformA(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["ModifiedPeptide"].split("_")[0]).strip()
 
-    tqdm.pandas(desc = "Annotating PeptidoformA...")
+    tqdm.pandas(desc = "Annotating peptidoform sequence A...")
     spectronaut["PP.PeptidoformA"] = spectronaut.progress_apply(lambda row: annotate_PeptidoformA(row, index), axis = 1)
 
     def annotate_PeptidoformB(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
         return str(index[key]["rows"][0]["ModifiedPeptide"].split("_")[1]).strip()
 
-    tqdm.pandas(desc = "Annotating PeptidoformB...")
+    tqdm.pandas(desc = "Annotating peptidoform sequence B...")
     spectronaut["PP.PeptidoformB"] = spectronaut.progress_apply(lambda row: annotate_PeptidoformB(row, index), axis = 1)
 
     def annotate_SourceScanID(row: pd.Series, index: dict) -> int:
         key = get_key_spectronaut(row)
         return int(index[key]["rows"][0]["scanID"])
 
-    tqdm.pandas(desc = "Annotating SourceScanID...")
+    tqdm.pandas(desc = "Annotating spectral library source scan ID...")
     spectronaut["PP.SourceScanID"] = spectronaut.progress_apply(lambda row: annotate_SourceScanID(row, index), axis = 1)
 
     return spectronaut

--- a/post_process.py
+++ b/post_process.py
@@ -211,7 +211,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
     def annotate_PartialCscoreA(row: pd.Series) -> float:
         cscore = row[SPECTRONAUT_CSCORE_COLUMN_NAME]
         partial = row["MatchedIonsA"] / (row["MatchedIonsA"] + row["MatchedIonsB"])
-        return csore * partial
+        return cscore * partial
 
     tqdm.pandas(desc = "Annotating partial Cscore A...")
     spectronaut["PartialCscoreA"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreA(row), axis = 1)
@@ -220,7 +220,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
     def annotate_PartialCscoreB(row: pd.Series) -> float:
         cscore = row[SPECTRONAUT_CSCORE_COLUMN_NAME]
         partial = row["MatchedIonsB"] / (row["MatchedIonsA"] + row["MatchedIonsB"])
-        return csore * partial
+        return cscore * partial
 
     tqdm.pandas(desc = "Annotating partial Cscore B...")
     spectronaut["PartialCscoreB"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreB(row), axis = 1)

--- a/post_process.py
+++ b/post_process.py
@@ -30,7 +30,7 @@ from typing import List
 
 ##################### POST PROCESS #####################
 
-def get_mz_key(mz: float) -> str:
+def get_mz_key(mz: float) -> float:
     #return str(int(mz * 1000))
     return mz
 

--- a/post_process.py
+++ b/post_process.py
@@ -92,7 +92,7 @@ def generate_fragment_index(spectronaut: pd.DataFrame, index: dict) -> Dict[str,
     fragment_annotation = dict()
     for i, row in tqdm(spectronaut.iterrows(), total = spectronaut.shape[0], desc = "Generating fragment ion index..."):
         key = get_key_spectronaut(row)
-        ion = float(row["F.MeasuredMz"])
+        ion = float(row[SPECTRONAUT_FRAGMENT_MZ_COLUMN_NAME])
         ions = index[key]["ions"]
         for current_ion_mz in ions.keys():
             if current_ion_mz > ion - SPECTRONAUT_MATCH_TOLERANCE and current_ion_mz < ion + SPECTRONAUT_MATCH_TOLERANCE:

--- a/post_process.py
+++ b/post_process.py
@@ -7,8 +7,8 @@
 
 
 # version tracking
-__version = "1.0.0"
-__date = "2025-02-20"
+__version = "1.1.0"
+__date = "2025-02-28"
 
 # PARAMETERS
 

--- a/post_process.py
+++ b/post_process.py
@@ -5,6 +5,13 @@
 # https://github.com/michabirklbauer/
 # micha.birklbauer@gmail.com
 
+# TODO
+# use argparse
+# clarify how to handle parameters, put in config.py?
+# what else to annotate?
+# update docs
+# do other TODOs (ctrl + f)
+
 # version tracking
 __version = "1.0.0"
 __date = "2025-02-20"
@@ -88,7 +95,8 @@ def read_spectral_library(filename: str) -> Dict[str, Dict[str, Any]]:
     return index
 
 def generate_fragment_index(spectronaut: pd.DataFrame, index: dict) -> Dict[str, Dict[str, int]]:
-
+    # TODO: Check if this is logically correct
+    # TODO: Write some docs
     fragment_annotation = dict()
     for i, row in tqdm(spectronaut.iterrows(), total = spectronaut.shape[0], desc = "Generating fragment ion index..."):
         key = get_key_spectronaut(row)

--- a/post_process.py
+++ b/post_process.py
@@ -9,6 +9,11 @@
 __version = "1.0.0"
 __date = "2025-02-20"
 
+# PARAMETERS
+SPECTRONAUT_MATCH_TOLERANCE = 0.02 # match tolerance in Da
+SPECTRONAUT_DELIM = "," #"\t" # delimiter in Spectronaut output file
+SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use for re-soring
+
 # REQUIREMENTS
 # pip install tqdm
 # pip install pandas

--- a/post_process.py
+++ b/post_process.py
@@ -223,3 +223,17 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
     spectronaut["DecoyType"] = spectronaut.progress_apply(lambda row: annotate_DecoyType(row, index), axis = 1)
 
     return spectronaut
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        raise RuntimeError("No Spectronaut file was given!")
+
+    filename = sys.argv[1]
+    filename_o = filename + "_annotated.csv"
+
+    df = annotate_spectronaut_result(filename)
+    print("Writing annotated Spectronaut result to file...")
+    df.to_csv(filename_o, index = False)
+    print("Finished annotation!")

--- a/post_process.py
+++ b/post_process.py
@@ -366,16 +366,18 @@ def main(argv = None) -> None:
                         version = __version)
     args = parser.parse_args(argv)
 
+    filename = args.file[0]
+
     if args.non_interactive:
-        r = annotate_spectronaut_result(args.file)
+        r = annotate_spectronaut_result(filename)
     else:
         y = input("Some Spectronaut specific parameters have to be set in the python script. " +
                   "Please refer to the documentation and confirm that you set the parameters accordingly [y/n]:")
         if y.lower().strip() not in ["y", "yes"]:
             raise RuntimeError("Post processing was terminated because of missing confirmation!")
-        r = annotate_spectronaut_result(args.file)
+        r = annotate_spectronaut_result(filename)
 
-    output_1 = args.file + "_annotated.csv"
+    output_1 = filename + "_annotated.csv"
     output_2 = output_1 + "_grouped_by_residue_pair.csv"
 
     print("Writing annotated Spectronaut result to file...")

--- a/post_process.py
+++ b/post_process.py
@@ -5,12 +5,6 @@
 # https://github.com/michabirklbauer/
 # micha.birklbauer@gmail.com
 
-# TODO
-# use argparse
-# clarify how to handle parameters, put in config.py?
-# what else to annotate?
-# update docs
-# do other TODOs (ctrl + f)
 
 # version tracking
 __version = "1.0.0"
@@ -42,7 +36,7 @@ from typing import List
 def get_mz_key(mz: float) -> float:
     #return str(int(mz * 1000))
     return mz
-    
+
 def get_fragment_key(mz: float) -> str:
     return f"{round(mz, 4):.4f}"
 

--- a/post_process.py
+++ b/post_process.py
@@ -7,7 +7,7 @@
 
 
 # version tracking
-__version = "1.1.0"
+__version = "1.1.1"
 __date = "2025-02-28"
 
 # PARAMETERS

--- a/post_process.py
+++ b/post_process.py
@@ -386,6 +386,7 @@ def main(argv = None) -> None:
     print("Writing grouped Spectronaut result to file...")
     g = group_by_residue_pair(r)
     g.to_csv(output_2, index = False)
+    print(f"Finished writing {output_2}.")
     print("Finished post processing!")
 
     return 0

--- a/post_process.py
+++ b/post_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # SPECTRONAUT POST PROCESSING
-# 2023 (c) Micha Johannes Birklbauer
+# 2025 (c) Micha Johannes Birklbauer
 # https://github.com/michabirklbauer/
 # micha.birklbauer@gmail.com
 

--- a/post_process.py
+++ b/post_process.py
@@ -18,7 +18,8 @@ __date = "2025-02-20"
 
 # PARAMETERS
 
-SPECTRONAUT_DELIM = "," #"\t" # delimiter in Spectronaut output file
+# these parameters should be set accordingly
+SPECTRONAUT_DELIM = "," # delimiter in Spectronaut output file, e.g. "," for comma delimited files, "\t" for tab delimited files
 SPECTRONAUT_MATCH_TOLERANCE = 0.05 # match tolerance in Da
 SPECTRONAUT_FRAGMENT_MZ_COLUMN_NAME = "F.CalibratedMz" # which F Mz to use for matching
 SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use for re-soring

--- a/post_process.py
+++ b/post_process.py
@@ -196,7 +196,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         return fragment_annotation[key]["matched_number_ions_a"]
 
     tqdm.pandas(desc = "Annotating number of matched ions A...")
-    spectronaut["MatchedIonsA"] = spectronaut.progress_apply(lambda row: annotate_MatchedIonsA(row, fragment_annotation), axis = 1)
+    spectronaut["PP.MatchedIonsA"] = spectronaut.progress_apply(lambda row: annotate_MatchedIonsA(row, fragment_annotation), axis = 1)
 
     # b
     def annotate_TotalIonsA(row: pd.Series, index: dict) -> int:
@@ -204,7 +204,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         return index[key]["total_ions_a"]
 
     tqdm.pandas(desc = "Annotating number of total ions A...")
-    spectronaut["TotalIonsA"] = spectronaut.progress_apply(lambda row: annotate_TotalIonsA(row, index), axis = 1)
+    spectronaut["PP.TotalIonsA"] = spectronaut.progress_apply(lambda row: annotate_TotalIonsA(row, index), axis = 1)
 
     # c
     def annotate_MatchedIonsB(row: pd.Series, fragment_annotation: dict) -> int:
@@ -212,7 +212,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         return fragment_annotation[key]["matched_number_ions_b"]
 
     tqdm.pandas(desc = "Annotating number of matched ions B...")
-    spectronaut["MatchedIonsB"] = spectronaut.progress_apply(lambda row: annotate_MatchedIonsB(row, fragment_annotation), axis = 1)
+    spectronaut["PP.MatchedIonsB"] = spectronaut.progress_apply(lambda row: annotate_MatchedIonsB(row, fragment_annotation), axis = 1)
 
     # d
     def annotate_TotalIonsB(row: pd.Series, index: dict) -> int:
@@ -220,41 +220,41 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         return index[key]["total_ions_b"]
 
     tqdm.pandas(desc = "Annotating number of total ions B...")
-    spectronaut["TotalIonsB"] = spectronaut.progress_apply(lambda row: annotate_TotalIonsB(row, index), axis = 1)
+    spectronaut["PP.TotalIonsB"] = spectronaut.progress_apply(lambda row: annotate_TotalIonsB(row, index), axis = 1)
 
     # e
     tqdm.pandas(desc = "Annotating relative match score A...")
-    spectronaut["RelativeMatchScoreA"] = spectronaut.progress_apply(lambda row: row["MatchedIonsA"] / row["TotalIonsA"], axis = 1)
+    spectronaut["PP.RelativeMatchScoreA"] = spectronaut.progress_apply(lambda row: row["PP.MatchedIonsA"] / row["PP.TotalIonsA"], axis = 1)
 
     # f
     tqdm.pandas(desc = "Annotating relative match score B...")
-    spectronaut["RelativeMatchScoreB"] = spectronaut.progress_apply(lambda row: row["MatchedIonsB"] / row["TotalIonsB"], axis = 1)
+    spectronaut["PP.RelativeMatchScoreB"] = spectronaut.progress_apply(lambda row: row["PP.MatchedIonsB"] / row["PP.TotalIonsB"], axis = 1)
 
     # g
     def annotate_PartialCscoreA(row: pd.Series) -> float:
         cscore = row[SPECTRONAUT_CSCORE_COLUMN_NAME]
-        partial = row["MatchedIonsA"] / (row["MatchedIonsA"] + row["MatchedIonsB"])
+        partial = row["PP.MatchedIonsA"] / (row["PP.MatchedIonsA"] + row["PP.MatchedIonsB"])
         return cscore * partial
 
     tqdm.pandas(desc = "Annotating partial Cscore A...")
-    spectronaut["PartialCscoreA"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreA(row), axis = 1)
+    spectronaut["PP.PartialCscoreA"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreA(row), axis = 1)
 
     # h
     def annotate_PartialCscoreB(row: pd.Series) -> float:
         cscore = row[SPECTRONAUT_CSCORE_COLUMN_NAME]
-        partial = row["MatchedIonsB"] / (row["MatchedIonsA"] + row["MatchedIonsB"])
+        partial = row["PP.MatchedIonsB"] / (row["PP.MatchedIonsA"] + row["PP.MatchedIonsB"])
         return cscore * partial
 
     tqdm.pandas(desc = "Annotating partial Cscore B...")
-    spectronaut["PartialCscoreB"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreB(row), axis = 1)
+    spectronaut["PP.PartialCscoreB"] = spectronaut.progress_apply(lambda row: annotate_PartialCscoreB(row), axis = 1)
 
     # i
     tqdm.pandas(desc = "Annotating composite relative match score...")
-    spectronaut["CompositeRelativeMatchScore"] = spectronaut.progress_apply(lambda row: min(row["RelativeMatchScoreA"], row["RelativeMatchScoreB"]), axis = 1)
+    spectronaut["PP.CompositeRelativeMatchScore"] = spectronaut.progress_apply(lambda row: min(row["PP.RelativeMatchScoreA"], row["PP.RelativeMatchScoreB"]), axis = 1)
 
     # j
     tqdm.pandas(desc = "Annotating composite partial Cscore...")
-    spectronaut["CompositePartialCscore"] = spectronaut.progress_apply(lambda row: min(row["PartialCscoreA"], row["PartialCscoreB"]), axis = 1)
+    spectronaut["PP.CompositePartialCscore"] = spectronaut.progress_apply(lambda row: min(row["PP.PartialCscoreA"], row["PP.PartialCscoreB"]), axis = 1)
 
     # annotation of other properties
     def annotate_DecoyType(row: pd.Series, index: dict) -> str:
@@ -262,7 +262,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
         return str(index[key]["rows"][0]["DecoyType"]).strip()
 
     tqdm.pandas(desc = "Annotating DecoyType...")
-    spectronaut["DecoyType"] = spectronaut.progress_apply(lambda row: annotate_DecoyType(row, index), axis = 1)
+    spectronaut["PP.DecoyType"] = spectronaut.progress_apply(lambda row: annotate_DecoyType(row, index), axis = 1)
 
     return spectronaut
 

--- a/post_process.py
+++ b/post_process.py
@@ -10,8 +10,10 @@ __version = "1.0.0"
 __date = "2025-02-20"
 
 # PARAMETERS
-SPECTRONAUT_MATCH_TOLERANCE = 0.05 # match tolerance in Da
+
 SPECTRONAUT_DELIM = "," #"\t" # delimiter in Spectronaut output file
+SPECTRONAUT_MATCH_TOLERANCE = 0.05 # match tolerance in Da
+SPECTRONAUT_FRAGMENT_MZ_COLUMN_NAME = "F.CalibratedMz" # which F Mz to use for matching
 SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use for re-soring
 
 # REQUIREMENTS

--- a/post_process.py
+++ b/post_process.py
@@ -33,6 +33,9 @@ from typing import List
 def get_mz_key(mz: float) -> float:
     #return str(int(mz * 1000))
     return mz
+    
+def get_fragment_key(mz: float) -> str:
+    return f"{round(mz, 4):.4f}"
 
 def get_key_spec_lib(row: pd.Series) -> str:
     # ModifiedPeptide

--- a/post_process.py
+++ b/post_process.py
@@ -84,7 +84,7 @@ def read_spectral_library(filename: str) -> Dict[str, Dict[str, Any]]:
 
 def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
 
-    spectronaut = pd.read_csv(filename, sep = "\t", low_memory = False)
+    spectronaut = pd.read_csv(filename, sep = SPECTRONAUT_DELIM, low_memory = False)
     filename_spec_lib = str(spectronaut["EG.Library"].at[0])
     index = read_spectral_library(filename_spec_lib)
 

--- a/post_process.py
+++ b/post_process.py
@@ -22,6 +22,7 @@ SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use fo
 from tqdm import tqdm
 import pandas as pd
 
+from typing import Any
 from typing import Dict
 from typing import List
 

--- a/post_process.py
+++ b/post_process.py
@@ -42,7 +42,13 @@ def get_key_spectronaut(row: pd.Series) -> str:
     # AAHHADGLAKGLHETC[Carbamidomethyl]K_M[Oxidation]FIPKSHTK.5
     # PG.ProteinNames
     # P10771_P10771-113_46
-    return f"{str(row['EG.PrecursorId']).strip()}:{str(row['PG.ProteinNames']).strip()}"
+    # ---> if PG.ProteinNames
+    # P10771_P10771
+    # use FG.Comment
+    # 113_46
+    if "-" in str(row["PG.ProteinNames"]):
+        return f"{str(row['EG.PrecursorId']).strip()}:{str(row['PG.ProteinNames']).strip()}"
+    return f"{str(row['EG.PrecursorId']).strip()}:{str(row['PG.ProteinNames']).strip()}-{str(row['FG.Comment']).strip()}"
 
 def read_spectral_library(filename: str) -> Dict[str, List[pd.Series]]:
 

--- a/post_process.py
+++ b/post_process.py
@@ -29,8 +29,9 @@ SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use fo
 # pip install pandas
 
 # import packages
-from tqdm import tqdm
+import argparse
 import pandas as pd
+from tqdm import tqdm
 
 from typing import Any
 from typing import Dict

--- a/post_process.py
+++ b/post_process.py
@@ -236,7 +236,7 @@ def annotate_spectronaut_result(filename: str) -> pd.DataFrame:
     # annotation of other properties
     def annotate_DecoyType(row: pd.Series, index: dict) -> str:
         key = get_key_spectronaut(row)
-        return str(index[key][0]["DecoyType"]).strip()
+        return str(index[key]["rows"][0]["DecoyType"]).strip()
 
     tqdm.pandas(desc = "Annotating DecoyType...")
     spectronaut["DecoyType"] = spectronaut.progress_apply(lambda row: annotate_DecoyType(row, index), axis = 1)

--- a/post_process.py
+++ b/post_process.py
@@ -360,7 +360,7 @@ def main(argv = None) -> None:
                         dest = "non_interactive",
                         action = "store_true",
                         default = False,
-                        help = "Skip inforamtion check.")
+                        help = "Skip information check.")
     parser.add_argument("--version",
                         action = "version",
                         version = __version)

--- a/post_process.py
+++ b/post_process.py
@@ -10,7 +10,7 @@ __version = "1.0.0"
 __date = "2025-02-20"
 
 # PARAMETERS
-SPECTRONAUT_MATCH_TOLERANCE = 0.02 # match tolerance in Da
+SPECTRONAUT_MATCH_TOLERANCE = 0.05 # match tolerance in Da
 SPECTRONAUT_DELIM = "," #"\t" # delimiter in Spectronaut output file
 SPECTRONAUT_CSCORE_COLUMN_NAME = "PG.Cscore (Run-Wise)" # which Cscore to use for re-soring
 

--- a/post_process.py
+++ b/post_process.py
@@ -28,6 +28,10 @@ from typing import List
 
 ##################### POST PROCESS #####################
 
+def get_mz_key(mz: float) -> str:
+    #return str(int(mz * 1000))
+    return mz
+
 def get_key_spec_lib(row: pd.Series) -> str:
     # ModifiedPeptide
     # DAKQRIVDK_NGVKM[Oxidation]C[Carbamidomethyl]PR

--- a/post_process.py
+++ b/post_process.py
@@ -95,15 +95,23 @@ def generate_fragment_index(spectronaut: pd.DataFrame, index: dict) -> Dict[str,
         ion = float(row[SPECTRONAUT_FRAGMENT_MZ_COLUMN_NAME])
         ions = index[key]["ions"]
         for current_ion_mz in ions.keys():
-            if current_ion_mz > ion - SPECTRONAUT_MATCH_TOLERANCE and current_ion_mz < ion + SPECTRONAUT_MATCH_TOLERANCE:
+            fragment_key_part = get_fragment_key(current_ion_mz)
+            if round(current_ion_mz, 4) > round(ion - SPECTRONAUT_MATCH_TOLERANCE, 4) and round(current_ion_mz, 4) < round(ion + SPECTRONAUT_MATCH_TOLERANCE, 4):
                 if key not in fragment_annotation:
                     fragment_annotation[key] = {"matched_number_ions_a": 0,
-                                                "matched_number_ions_b": 0}
+                                                "matched_number_ions_b": 0,
+                                                "fragments": []}
                 for current_ion in ions[current_ion_mz]:
                     if current_ion["FragmentPepId"] == 0:
-                        fragment_annotation[key]["matched_number_ions_a"] += 1
+                        fragment_key = fragment_key_part + "_0"
+                        if fragment_key not in fragment_annotation[key]["fragments"]:
+                            fragment_annotation[key]["matched_number_ions_a"] += 1
+                            fragment_annotation[key]["fragments"].append(fragment_key)
                     else:
-                        fragment_annotation[key]["matched_number_ions_b"] += 1
+                        fragment_key = fragment_key_part + "_1"
+                        if fragment_key not in fragment_annotation[key]["fragments"]:
+                            fragment_annotation[key]["matched_number_ions_b"] += 1
+                            fragment_annotation[key]["fragments"].append(fragment_key)
 
     return fragment_annotation
 


### PR DESCRIPTION
adds the following scores to the Spectronaut output
- matched number ions a
- total number ions a
- matched number ions b
- total number ions b
- relative match score a (a / b)
- relative match score b (c / d)
- partial c score a (c score * (a / a + c))
- partial c score b (c score * (c / a + c))
- composite relative match score min(e, f)
- composite partial c score min(g, h)

Several todos still open before merge!
Q: How to test?