### PR TITLE
Optimze MS file reading

### DIFF
--- a/create_spectral_library.py
+++ b/create_spectral_library.py
@@ -16,8 +16,8 @@
 # micha.birklbauer@gmail.com
 
 # version tracking
-__version = "1.4.13"
-__date = "2025-08-06"
+__version = "1.4.14"
+__date = "2025-09-24"
 
 # REQUIREMENTS
 # pip install pandas


### PR DESCRIPTION
- MS files are now loaded on demand and only one MS file is kept in memory at a time
- CSMs are sorted by spectrum file to minimize file loading
- Retention time is extracted directly from the MGF or MZML file instead of from the CSM table